### PR TITLE
DOC: Adjust the project submission template to BHG

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-submission-template.md
+++ b/.github/ISSUE_TEMPLATE/project-submission-template.md
@@ -9,16 +9,16 @@ assignees: ''
 
 <!-- Guidelines
 
-We are very excited to meet you at the 2020 Brainhack Donostia 🎉 To submit a project, you need to be an attendee of the 2020 Brainhack Donostia. We ask you to register first over here. Thank you!
+We are very excited to meet you at Brainhack Global 2020 🎉 To submit a project, you need to be an attendee to one of the Brainhack Global 2020 events. Please, register to the event that is most suitable to your location, time zone, interest, and/or project prior to submitting one. Thank you!
 
 We have prepared a checklist to help with your project submission. Here is how to proceed:
 
 Before filling in any part, please submit this issue
 Check items in the checklist below as you go through them
-Once you are done (at least all 'required' items must be provided), please delete the "Guidelines" section and add a comment saying 'hi @Brainhack-Donostia/project-monitors: My project is ready!'
+Once you are done (at least all 'required' items must be provided), please delete the "Guidelines" section and add a comment saying 'Hi @Brainhack-Global/project-monitors: my project is ready!'
 Thank you!
 
-After step 1 (issue submitted), we will assign a 'project monitor' to follow your submission. If at any time you need help or anything is unclear, please add a comment and ping your project monitor. Our team is here to help! -->
+After step 1 (issue submitted), we will assign a 'project monitor' from the event that you will be attending to follow your submission. If at any time you need help or anything is unclear, please add a comment and ping your project monitor. Our team is here to help! -->
 
 ## Project info
 
@@ -26,13 +26,19 @@ After step 1 (issue submitted), we will assign a 'project monitor' to follow you
 <!-- Add a title that reflects what the code (or content) will do in a way that makes sense to newcomers who want to contribute to your project. -->
 
 **Project lead:**
-<!-- Add name (and Twitter and Mattermost handle if possible) of contact person. -->
+<!-- Add full name (and Twitter and Mattermost handle if possible) of the contact person. -->
 
 **Project collaborators**
-<!-- Add names (and Twitter handles if possible) of any person contributing to the project. Try to follow the [all-contributors specification](https://github.com/all-contributors/all-contributors). Contributions of any kind are welcome! -->
+<!-- Add full names (and Twitter handles if possible) of any person contributing to the project. Try to follow the [all-contributors specification](https://github.com/all-contributors/all-contributors). Contributions of any kind are welcome! -->
+
+**Brainhack Global 2020 event**
+<!-- Specify the city and country of the Brainhack Global 2020 event that you
+registered for. If your local event has a special name or topic (e.g. Brainhack
+London - Clinical Nuroanatomy), please do specify that as well to help us
+distinguish between potential events in the same city. -->
 
 **Description:**
-<!-- Add a brief description of the project. Try to include all the relevant information to answer the following questions: 
+<!-- Add a brief description of the project. Try to include all the relevant information to answer the following questions:
 What are you doing, for who, and why;
 What makes your project special and exciting;
 A short example;
@@ -45,14 +51,14 @@ Where to find key resources; -->
 **Link to project:**
 <!-- Add a link to the project’s GitHub repo or website. -->
 
-**Goals for Brainhack Donostia:**
+**Goals for Brainhack Global 2020:**
 <!-- Add a list of milestones or deliverables that you expect to achieve during the event. Try to provide goals of varying complexity for contributors with different sets of skills. -->
 
 **Good first issues:**
 <!-- Add a list of tasks to help new contributors find easy gateways into open source projects. -->
 
-1. 
-2. 
+1.
+2.
 
 **Skills:**
 <!-- Add a list of skills needed to contribute to this project. Try to think of both coding and non-coding skills. You can provide predefined skill levels, but it’s better if you give concrete examples of the type of task contributors will be facing. -->
@@ -66,21 +72,21 @@ Where to find key resources; -->
 
 *Once the issue is submitted, please check items in this list as you add under ‘Additional project info’*
 
-- [ ] Link to your project: could be a code repository, a shared document, etc. See [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#link-to-project).
-- [ ] Goals for Brainhack Donostia: describe what you want to achieve during this brainhack. See [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#goals).
-- [ ] Flesh out at least 2 “good first issues”: those are tasks that do not require any prior knowledge about your project, could be defined as issues in a GitHub repository, or in a shared document, cf. [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#onboarding-2-good-first-issues).
-- [ ] Skills: list skills that would be particularly suitable for your project. We ask you to include at least one non-coding skill, cf. [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#onboarding-skills).
-- [ ] Chat channel: A link to a chat channel that will be used during the OHBM Brainhack. This can be an existing channel or a new one. We recommend using the [Brainhack space on mattermost](https://mattermost.brainhack.org/), cf. [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#chat).
-- [ ] Video channel: A link to a video channel that will be used during the OHBM Brainhack. This can be an existing channel or a new one. For instance a [jitsi meet room](https://meet.jit.si/), cf. [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#video-calls).
+- [ ] Link to your project: could be a code repository, a shared document, etc.
+- [ ] Goals for Brainhack Global 2020: describe what you want to achieve during this brainhack.
+- [ ] Flesh out at least 2 “good first issues”: those are tasks that do not require any prior knowledge about your project, could be defined as issues in a GitHub repository, or in a shared document.
+- [ ] Skills: list skills that would be particularly suitable for your project. We ask you to include at least one non-coding skill. Use the issue labels for this purpose.
+- [ ] Chat channel: A link to a chat channel that will be used during the Brainhack Global 2020 event. This can be an existing channel or a new one. We recommend using the [Brainhack space on mattermost](https://mattermost.brainhack.org/).
+- [ ] Video channel: A link to a video channel that will be used during the Brainhack Global 2020 Brainhack. This can be an existing channel or a new one. For instance a [jitsi meet room](https://meet.jit.si/) **Please, do not make the video channel public in here**: post a message in your chat channel and pin it so that it remains private, you do not get undesired content, and contributors can still have access to it..
 
 Optionally, you can also include information about:
 
-- [ ] Number of participants, cf. [No limit. Anyone interested to learn can use the tutorials. There are multiple updates and fixes that need to happen, so multiple people can make contributions](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#participant-capacity).
-- [ ] Twitter-size summary of your project pitch, cf. [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#twitter-size-summary-of-your-project-pitch).
-- [ ] Provide an image of your project for the OHBM brainhack website.
-- [ ] Project snippet for the OHBM Brainhack website, cf. [here](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#project-snippet-for-the-ohbm-brainhack-website).
+- [ ] Number of participants.
+- [ ] Twitter-size summary of your project pitch.
+- [ ] Provide an image of your project for the Brainhack Global 2020 website.
+- [ ] Short project description for the Brainhack Global 2020 website.
 
-We would like to think about how you will credit and onboard new members to your project. We recommend reading references from [this section](https://github.com/ohbm/hackathon2020/blob/master/.github/ISSUE_TEMPLATE/handbooks/projects.md#credit-and-onboarding). If you’d like to share your thoughts with future project participants, you can include information about:
+We would like to think about how you will credit and onboard new members to your project. If you’d like to share your thoughts with future project participants, you can include information about:
 
 - [ ] Specify how you will acknowledge contributions (e.g. listing members on a contributing page).
 - [ ] Provide links to onboarding documents if you have some: [https://brainiak.org/tutorials/](https://brainiak.org/tutorials/)

--- a/.github/ISSUE_TEMPLATE/project-submission-template.md
+++ b/.github/ISSUE_TEMPLATE/project-submission-template.md
@@ -1,7 +1,7 @@
 ---
-name: "[WIP] Project submission template"
-about: Fill this template to submit the project
-title: "[Project]"
+name: "Project submission template"
+about: Fill this template to submit a project
+title: ""
 labels: project
 assignees: ''
 
@@ -9,7 +9,7 @@ assignees: ''
 
 <!-- Guidelines
 
-We are very excited to meet you at Brainhack Global 2020 🎉 To submit a project, you need to be an attendee to one of the Brainhack Global 2020 events. Please, register to the event that is most suitable to your location, time zone, interest, and/or project prior to submitting one. Thank you!
+We are very excited to meet you at Brainhack Global 2020 🎉. To submit a project, you need to be an attendee to one of the Brainhack Global 2020 events. Please, register to the event that is most suitable to your location, time zone, interest, and/or project prior to submitting one. Thank you!
 
 We have prepared a checklist to help with your project submission. Here is how to proceed:
 
@@ -18,7 +18,9 @@ Check items in the checklist below as you go through them
 Once you are done (at least all 'required' items must be provided), please delete the "Guidelines" section and add a comment saying 'Hi @Brainhack-Global/project-monitors: my project is ready!'
 Thank you!
 
-After step 1 (issue submitted), we will assign a 'project monitor' from the event that you will be attending to follow your submission. If at any time you need help or anything is unclear, please add a comment and ping your project monitor. Our team is here to help! -->
+After step 1 (issue submitted), we will assign a 'project monitor' from the event that you will be attending to follow your submission. Once the submission is approved by the 'project monitor', they will add the label 'Website ready' and it will appear on https://brainhack.org/global2020/projects page. Note that you can always update your issue and your page on the website will change accordingly.
+
+If at any time you need help or anything is unclear, please add a comment and ping your project monitor. Our team is here to help! -->
 
 ## Project info
 
@@ -45,7 +47,7 @@ A short example;
 How to get started;
 Where to find key resources; -->
 
-**Data**
+**Data:**
 <!-- If your project uses data, add a short description of the data and a link to its source. -->
 
 **Link to project:**
@@ -76,15 +78,15 @@ Where to find key resources; -->
 - [ ] Goals for Brainhack Global 2020: describe what you want to achieve during this brainhack.
 - [ ] Flesh out at least 2 “good first issues”: those are tasks that do not require any prior knowledge about your project, could be defined as issues in a GitHub repository, or in a shared document.
 - [ ] Skills: list skills that would be particularly suitable for your project. We ask you to include at least one non-coding skill. Use the issue labels for this purpose.
-- [ ] Chat channel: A link to a chat channel that will be used during the Brainhack Global 2020 event. This can be an existing channel or a new one. We recommend using the [Brainhack space on mattermost](https://mattermost.brainhack.org/).
-- [ ] Video channel: A link to a video channel that will be used during the Brainhack Global 2020 Brainhack. This can be an existing channel or a new one. For instance a [jitsi meet room](https://meet.jit.si/) **Please, do not make the video channel public in here**: post a message in your chat channel and pin it so that it remains private, you do not get undesired content, and contributors can still have access to it..
+- [ ] Chat channel: A link to a chat channel that will be used during the Brainhack Global 2020 event. This can be an existing channel or a new one. We recommend using the [Brainhack space on Mattermost](https://mattermost.brainhack.org/).
+- [ ] Video channel: A link to a video channel that will be used during the Brainhack Global 2020 Brainhack. This can be an existing channel or a new one. For instance a [Jitsi meet room](https://meet.jit.si/). **Please, do not make the video channel public in here**: post a message in your chat channel and pin it so that it remains private, you do not get undesired content, and contributors can still have access to it..
 
 Optionally, you can also include information about:
 
 - [ ] Number of participants.
 - [ ] Twitter-size summary of your project pitch.
-- [ ] Provide an image of your project for the Brainhack Global 2020 website.
-- [ ] Short project description for the Brainhack Global 2020 website.
+<!-- You can put an image anywhere in this issue and it will be used in to build your project page on the website. -->
+- [ ] Provide an image of your project for the Brainhack Global 2020 website. 
 
 We would like to think about how you will credit and onboard new members to your project. If you’d like to share your thoughts with future project participants, you can include information about:
 


### PR DESCRIPTION
Adjust the project submission template to BHG:
- Remove non-BHG references from project submission template.
- Ask submitters to specify the BHG event location so that the appropriate
  labels can be assigned and reveiwers can filter the projects.
- Warn submitters not to publicly share their video channel.