### PR TITLE
allow only one highlighted menu item at a time

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -15,7 +15,7 @@
 [[main]]
   pre = "<i class='fas fa-search-location'></i>"
   name = "&nbsp; Events"
-  url = "../global2020/events" 
+  url = "../global2020/events/" 
 # "https://brainhack.org/global2020/events"
   weight = 20
   # identifier = "event"
@@ -35,7 +35,7 @@
 [[main]]
   pre = "<i class='fas fa-laptop'></i>"
   name = "&nbsp; Projects"
-  url = "../global2020/projects"
+  url = "../global2020/projects/"
   weight = 30
 
 [[main]]
@@ -59,7 +59,7 @@
 [[main]]
   # pre = "<i class='fas fa-question-circle'></i>"
   name = "FAQ"
-  url = "../global2020/faq"
+  url = "../global2020/faq/"
   weight = 70
   # identifier = "faq"
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -87,11 +87,11 @@
         {{ $is_same_page := false }}
         {{ $hash := findRE "#(.+)" .URL }}
 
-        {{ if (or (eq .URL "/") (eq .URL "")) }}
+        {{ if $current_page.IsHome | and (or (eq .URL "/") (eq .URL "")) }}
           {{ $is_link_in_current_path = true }}
         {{else}}
           {{ if gt (len .URL) 1 }}{{/* Ignore root URL */}}
-            {{ $is_link_in_current_path = in $current_page.RelPermalink (path.Base .URL) }}
+            {{ $is_link_in_current_path = in (path.Base $current_page.RelPermalink) (path.Base .URL) }}
             {{ $is_same_page = $is_link_in_current_path }}
           {{end}}
           {{ if gt (len $hash) 0 }}


### PR DESCRIPTION
Addressing issue #34 --> adapted `layouts/partials/navbar.html`.
Hiccup: When going from either the *Events*, *Projects* or *FAQ* page, to the *Team* or *Contact* page (part of the *Home* page) the *Home* menu item is, in a first instance, briefly highlighted as well. However, the active highlight is almost immediately switched to the *Team* or *Contact* menu item accordingly. 

![20201019_142701](https://user-images.githubusercontent.com/23309041/96451070-55ebda00-1217-11eb-9605-dad9b086401b.gif)
