### PR TITLE
Add labeller based on issue body content

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-submission-template.md
+++ b/.github/ISSUE_TEMPLATE/project-submission-template.md
@@ -72,6 +72,52 @@ Where to find key resources; -->
 
 <!-- [ ] Video channel: Please write here the communication channel (Zoom, Jitsi, Twitch, or any other platform) you will be using to work collaboratively however please keep them as commented to avoid any public sharing. Once you set up your project Mattermost communication channel, make sure you write the link of the video channel at the header of the Mattermost channel for your attendees to know --> 
 
+**Project labels**
+<!-- Please prepend an hashtag (#) to all of the labels that fit your project, then tick the box below to state you did so (either by adding an 'x' between square brackets, or by ticking it after submisison).
+E.g. my project is about the modulatory effect of salmon mousse on british supper survival
+In the following list:
+```
+meal:
+brunch, supper
+type:
+mousse, salmon, squid
+```
+I'm going to hashtag all of the labels I need my project to be indexed in:
+```
+meal:
+brunch, #supper
+type:
+#mousse, #salmon, squid
+```
+
+Now the real list (please indicate all of the labels you'd like to add to your project):
+- Type of project:
+coding_methods, data_management, documentation, method_development,
+pipeline_development, tutorial_recording, visualisation
+- Project development status:
+0_concept_no_content, 1_basic structure, 2_releases_existing
+- Topic of the projet:
+Bayesian_approaches, causality, connectome, data_visualisation, deep_learning,
+diffusion, diversity_inclusivity_equality, EEG_EventRelatedResponseModelling,
+EEG_source_modelling, Granger_causality, hypothesis_testing, ICA, information_theory,
+machine_learning, MR_methodologies, neural_decoding, neural_encoding, neural_networks,
+PCA, physiology, reinforcement_learning, reproducible_scientific_methods, single_neuron_models,
+statistical_modelling, systems_neuroscience, tractography
+- Tools used in the project:
+AFNI, ANTs, BIDS, Brainstorm, CPAC, Datalad, DIPY, FieldTrip, fMRIPrep, Freesurfer,
+FSL, Jupyter, MNE, MRtrix, Nipype, NWB, SPM
+- Tools skill level required to enter the project (more than one possible):
+comfortable, expert, familiar, no_skills_required
+- Programming language used in the project:
+no_programming_involved, C++, containerization, documentation, Java, Julia, Matlab,
+Python, R, shell_scripting, Unix_command_line, Web, workflows
+- Modalities involved in the project (if any):
+behavioral, DWI, ECG, ECOG, EEG, eye_tracking, fMRI, fNIRS, MEG, MRI, PET, TDCS, TMS
+- Git skills reuired to enter the project (more than one possible):
+0_no_git_skills, 1_commit_push, 2_branches_PRs, 3_continuous_integration
+-->
+- [ ] I added all of the labels I want associate to my project
+
 ## Project Submission
 
 ### Submission checklist

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,184 @@
+# All the possible labels, except for "status" labels and repo mainteinance labels (e.g. "bug")
+
+# Git skills labels
+git_skills:0_none:
+    - '#0_no_git_skills'
+git_skills:1_commit_push:
+    - '#1_commit_push'
+git_skills:2_branches_PRs:
+    - '#2_branches_PRs'
+git_skills:3_continuous_integration:
+    - '#3_continuous_integration'
+# Modality labels
+modality:behavioral:
+    - '#behavioral'
+modality:DWI:
+    - '#DWI'
+modality:ECG:
+    - '#ECG'
+modality:ECOG:
+    - '#ECOG'
+modality:EEG:
+    - '#EEG'
+modality:eye_tracking:
+    - '#eye_tracking'
+modality:fMRI:
+    - '#fMRI'
+modality:fNIRS:
+    - '#fNIRS'
+modality:MEG:
+    - '#MEG'
+modality:MRI:
+    - '#MRI'
+modality:PET:
+    - '#PET'
+modality:TDCS:
+    - '#TDCS'
+modality:TMS:
+    - '#TMS'
+# Programming labels
+programming:C++:
+    - '#C++'
+programming:containerization:
+    - '#containerization'
+programming:documentation:
+    - '#documentation'
+programming:Java:
+    - '#Java'
+programming:Julia:
+    - '#Julia'
+programming:Matlab:
+    - '#Matlab'
+programming:none:
+    - '#no_programming_involved'
+programming:Python:
+    - '#Python'
+programming:R:
+    - '#R'
+programming:shell_scripting:
+    - '#shell_scripting'
+programming:Unix_command_line:
+    - '#Unix_command_line'
+programming:Web:
+    - '#Web'
+programming:workflows:
+    - '#workflows'
+# Project development status labels
+project_development_status:0_concept_no_content:
+    - '#0_concept_no_content'
+project_development_status:1_basic structure:
+    - '#1_basic structure'
+project_development_status:2_releases_existing:
+    - '#2_releases_existing'
+# Skill level labels
+project_tools_skills:comfortable:
+    - '#comfortable'
+project_tools_skills:expert:
+    - '#expert'
+project_tools_skills:familiar:
+    - '#familiar'
+project_tools_skills:none:
+    - '#no_skills_required'
+# Project type labels
+project_type:coding_methods:
+    - '#coding_methods'
+project_type:data_management:
+    - '#data_management'
+project_type:documentation:
+    - '#documentation'
+project_type:method_development:
+    - '#method_development'
+project_type:pipeline_development:
+    - '#pipeline_development'
+project_type:tutorial_recording:
+    - '#tutorial_recording'
+project_type:visualisation:
+    - '#visualisation'
+# Tool labels
+tools:AFNI:
+    - '#AFNI'
+tools:ANTs:
+    - '#ANTs'
+tools:BIDS:
+    - '#BIDS'
+tools:Brainstorm:
+    - '#Brainstorm'
+tools:CPAC:
+    - '#CPAC'
+tools:Datalad:
+    - '#Datalad'
+tools:DIPY:
+    - '#DIPY'
+tools:FieldTrip:
+    - '#FieldTrip'
+tools:fMRIPrep:
+    - '#fMRIPrep'
+tools:Freesurfer:
+    - '#Freesurfer'
+tools:FSL:
+    - '#FSL'
+tools:Jupyter:
+    - '#Jupyter'
+tools:MNE:
+    - '#MNE'
+tools:MRtrix:
+    - '#MRtrix'
+tools:Nipype:
+    - '#Nipype'
+tools:NWB:
+    - '#NWB'
+tools:SPM:
+    - '#SPM'
+# Topic labels
+topic:Bayesian_approaches:
+    - '#Bayesian_approaches'
+topic:causality:
+    - '#causality'
+topic:connectome:
+    - '#connectome'
+topic:data_visualisation:
+    - '#data_visualisation'
+topic:deep_learning:
+    - '#deep_learning'
+topic:diffusion:
+    - '#diffusion'
+topic:diversity_inclusivity_equality:
+    - '#diversity_inclusivity_equality'
+topic:EEG_EventRelatedResponseModelling:
+    - '#EEG_EventRelatedResponseModelling'
+topic:EEG_source_modelling:
+    - '#EEG_source_modelling'
+topic:Granger_causality:
+    - '#Granger_causality'
+topic:hypothesis_testing:
+    - '#hypothesis_testing'
+topic:ICA:
+    - '#ICA'
+topic:information_theory:
+    - '#information_theory'
+topic:machine_learning:
+    - '#machine_learning'
+topic:MR_methodologies:
+    - '#MR_methodologies'
+topic:neural_decoding:
+    - '#neural_decoding'
+topic:neural_encoding:
+    - '#neural_encoding'
+topic:neural_networks:
+    - '#neural_networks'
+topic:PCA:
+    - '#PCA'
+topic:physiology:
+    - '#physiology'
+topic:reinforcement_learning:
+    - '#reinforcement_learning'
+topic:reproducible_scientific_methods:
+    - '#reproducible_scientific_methods'
+topic:single_neuron_models:
+    - '#single_neuron_models'
+topic:statistical_modelling:
+    - '#statistical_modelling'
+topic:systems_neuroscience:
+    - '#systems_neuroscience'
+topic:tractography:
+    - '#tractography'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: github/issue-labeler@v2.2
       with:
         # Secret token needed (not sure which permisions though)
-        repo-token: "${{ secrets.GH_TOKEN }}"
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
         # File with label/regex match dictionary
         configuration-path: .github/labeler.yml
         # The issues opened before this date will be ignored

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,5 @@
 name: "Label from issue first message body"
+# See https://github.com/marketplace/actions/regex-issue-labeler
 
 on:
   issues:
@@ -8,9 +9,13 @@ jobs:
   triage:
     runs-on: ubuntu-18.04
     steps:
-    - uses: github/issue-labeler@v2.0
+    - uses: github/issue-labeler@v2.2
       with:
+        # Secret token needed (not sure which permisions though)
         repo-token: "${{ secrets.GH_TOKEN }}"
+        # File with label/regex match dictionary
         configuration-path: .github/labeler.yml
+        # The issues opened before this date will be ignored
         not-before: 2020-10-29T00:00:00Z
+        # This can be increased if the dictionary undergoes a breaking change
         enable-versioned-regex: 0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: "Label from issue first message body"
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: github/issue-labeler@v2.0
+      with:
+        repo-token: "${{ secrets.GH_TOKEN }}"
+        configuration-path: .github/labeler.yml
+        not-before: 2020-10-29T00:00:00Z
+        enable-versioned-regex: 0


### PR DESCRIPTION
This PR adds the possibility for participants to label their project without having to select them (permission issues).
It works by pre-pending an hashtag to the elements of a list that contains a match for all project-related labels.
The project issue template has a new section (commented) that takes care of that.

Granted, it might not be the *most* elegant solution for this problem, but it's a solution nonetheless.

If you're wondering why an hashtag and not a set of ticking boxes, check my attempts of implementation [here](https://github.com/smoia/congenial-octo-rotary-phone). Granted, the attempts were made with version 2.0 of the action, this implementation uses the latest version (atm 2.2), so maybe there are slight differences.

In order to work, the workflow needs an auth token. I don't know if the existing one will work for it (it depends on the permissions).